### PR TITLE
disable segment tracking in js applet

### DIFF
--- a/js-applet/src/index.ts
+++ b/js-applet/src/index.ts
@@ -18,7 +18,7 @@ class PyNVL {
     options: NvlOptions = {},
     callbacks = {}
   ) {
-    this.nvl = new NVL(frame, nvlNodes, nvlRels, options, callbacks)
+    this.nvl = new NVL(frame, nvlNodes, nvlRels, { ...options, disableTelemetry: true }, callbacks)
     this.zoomInteraction = new ZoomInteraction(this.nvl)
     this.panInteraction = new PanInteraction(this.nvl)
     this.dragNodeInteraction = new DragNodeInteraction(this.nvl)


### PR DESCRIPTION
Removes Segment tracking from the JS applet to address the error `{'level': 'SEVERE', 'message': 'file:///tmp/pytest-of-runner/pytest-0/test_basic_render0/ajs-destination.js - Failed to load resource: net::ERR_FILE_NOT_FOUND', 'source': 'network', 'timestamp': 1733478509577}]` causing flakyness in testing.

https://trello.com/c/b30FLufJ/191-add-segment-tracking-for-python-wrapper-and-disable-tracking-in-python-tests
