### PR TITLE
Make sure to drop temp internal node props in `from_gds`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@
 
 ## Bug fixes
 
+* Make sure that temporary internal node properties are not included in the visualization output.
+
 
 ## Improvements
 

--- a/python-wrapper/src/neo4j_viz/gds.py
+++ b/python-wrapper/src/neo4j_viz/gds.py
@@ -119,6 +119,10 @@ def from_gds(
             node_properties = [property_name]
 
         node_dfs = _fetch_node_dfs(gds, G_fetched, node_properties, G_fetched.node_labels())
+        if property_name is not None:
+            for df in node_dfs.values():
+                df.drop(columns=[property_name], inplace=True)
+
         rel_df = _fetch_rel_df(gds, G_fetched)
     finally:
         if G_fetched.name() != G.name():

--- a/python-wrapper/tests/test_gds.py
+++ b/python-wrapper/tests/test_gds.py
@@ -276,6 +276,9 @@ def test_from_gds_sample(gds: Any) -> None:
         ):
             VG = from_gds(gds, G)
 
+        # Make sure internal temporary properties are not present
+        assert set(VG.nodes[0].properties.keys()) == {"labels"}
+
         assert len(VG.nodes) >= 9_500
         assert len(VG.nodes) <= 10_500
         assert len(VG.relationships) >= 9_500


### PR DESCRIPTION
Thank you for your contribution to the Graph Visualization for Python project by Neo4j.

<!-- Please include a summary of the change, such as, which issue was fixed or feature was added.
If relevant, link to the corresponding issue.
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please read [Contributing to the Neo4j Ecosystem](https://github.com/neo4j/python-graph-visualization/blob/main/CONTRIBUTING.md).

Make sure:
- [x] You signed the [Neo4j CLA](https://neo4j.com/developer/cla/#sign-cla) (Contributor License Agreement) so that we are allowed to ship your code in our library
- [x] Your contribution is covered by tests
